### PR TITLE
Added nil check to GetContainerItemInfo return val

### DIFF
--- a/SellJunk.lua
+++ b/SellJunk.lua
@@ -99,7 +99,7 @@ function addon:Sell()
   for bag = 0,4 do
     for slot = 1,C_Container.GetContainerNumSlots(bag) do
       local item = C_Container.GetContainerItemInfo(bag, slot)
-      if item['hyperlink'] then
+      if item and item['hyperlink'] then
 				-- is it grey quality item?
         local grey = item['quality'] == 0
 


### PR DESCRIPTION
Resolves a NPE that prevented SellJunk from continuing through the list of items: https://github.com/Beast-Masters-addons/SellJunk/issues/2